### PR TITLE
Add content of a file in a block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 /.idea
+*.blk

--- a/playground/Makefile
+++ b/playground/Makefile
@@ -1,0 +1,7 @@
+.PHONY: inspect
+
+test.blk:
+	cargo run -- create $@ ../src/*
+
+inspect: test/.blk
+	cargo run -- inspect $<

--- a/playground/Makefile
+++ b/playground/Makefile
@@ -1,7 +1,12 @@
 .PHONY: inspect
 
-test.blk:
+TEST_BLOCK=test.blk
+
+clean: 
+	rm -f ${TEST_BLOCK}
+
+test.blk: clean
 	cargo run -- create $@ ../src/*
 
-inspect: test/.blk
-	cargo run -- inspect $<
+inspect: ${TEST_BLOCK}
+	cargo run -- inspect -v $<

--- a/src/block.rs
+++ b/src/block.rs
@@ -260,7 +260,9 @@ impl Block {
         let data = self.mmap.as_ref();
 
         let mut cursor = Cursor::new(&data[info.offset as usize..]);
-        let header = FileHeader::decode(&mut cursor).chain_err(|| ErrorKind::HeaderCorrupted).unwrap();
+        let header = FileHeader::decode(&mut cursor)
+            .chain_err(|| ErrorKind::HeaderCorrupted)
+            .unwrap();
 
         let start = (info.offset as u64 + cursor.position()) as usize;
         let end = start + (info.size as usize);
@@ -268,7 +270,8 @@ impl Block {
     }
 
     pub fn file_by_id(&self, id: u64) -> Option<(FileHeader, &[u8])> {
-        self.header.file_info
+        self.header
+            .file_info
             .iter()
             .enumerate()
             .find(|(_, info)| info.id == id)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 extern crate error_chain;
+extern crate clap;
 
 pub mod block;
 
@@ -23,6 +24,7 @@ pub mod errors {
         }
         foreign_links {
             Io(::std::io::Error);
+            Clap(::clap::Error);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,14 @@ pub mod errors {
             BlockCorrupted {
                 description("Illegal block structure")
             }
+
+            HeaderCorrupted {
+                description("Header corrupted")
+            }
+
+            BlockFileAlreadyExists(path: String) {
+                display("Block file already exists: {}", path)
+            }
         }
         foreign_links {
             Io(::std::io::Error);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #[macro_use]
 extern crate error_chain;
-extern crate clap;
 
 pub mod block;
 
@@ -24,7 +23,6 @@ pub mod errors {
         }
         foreign_links {
             Io(::std::io::Error);
-            Clap(::clap::Error);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ fn create(block_path: impl AsRef<Path>, files: Values) -> Result<()> {
         .collect::<Vec<_>>();
     Block::from_files(block_path, &files)
         .map(|_| ())
-        .chain_err(|| "Unable to open file")
+        .chain_err(|| "Unable to create block")
 }
 
 /// Выводит информацию о содержимом блока
@@ -73,20 +73,25 @@ fn inspect(block_paths: Values) -> Result<()> {
         let block =
             Block::open(block_path).chain_err(|| format!("Fail to open block: {}", block_path))?;
         out.write_fmt(format_args!(
-            "{id:>10} {size:>10} {offset:>10} {hash:>35}\n",
+            "{id:>10} {size:>10} {offset:>10} {location_hash:>32} {content_hash:>32} {location:}\n",
             id = "ID",
             size = "SIZE",
             offset = "OFFSET",
-            hash = "HASH",
+            location_hash = "LOCATION HASH",
+            content_hash = "CONTENT HASH",
+            location = "LOCATION",
         ))?;
 
-        for file in block.iter() {
+        for (idx, file) in block.iter().enumerate() {
+            let (header, _) = block.file_at(idx)?;
             out.write_fmt(format_args!(
-                "{id:>10} {size:>10} {offset:>10}    {hash:x}\n",
+                "{id:>10} {size:>10} {offset:>10} {location_hash:x} {content_hash:x} {location:<}\n",
                 id = file.id,
                 size = file.size,
                 offset = file.offset,
-                hash = file.location_hash
+                location_hash = file.location_hash,
+                content_hash = header.hash,
+                location = header.location,
             ))?;
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,20 @@ extern crate error_chain;
 extern crate blocky;
 
 use ::blocky::block::{AddFileRequest, Block};
-use ::blocky::errors::*;
 use clap::{App, ArgMatches, SubCommand};
 use std::io::{self, stdout, BufWriter, Write};
+
+mod errors {
+    error_chain! {
+        foreign_links {
+            Clap(::clap::Error);
+            Io(::std::io::Error);
+            Blocky(::blocky::errors::Error);
+        }
+    }
+}
+
+use errors::*;
 
 quick_main!(application);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ extern crate blocky;
 use ::blocky::block::{AddFileRequest, Block};
 use ::blocky::errors::*;
 use clap::{App, ArgMatches, SubCommand};
-use std::io::{self, Write};
+use std::io::{self, Write, stdout, BufWriter};
 
 quick_main!(application);
 
@@ -66,8 +66,8 @@ fn create(opts: &ArgMatches) -> Result<()> {
 fn inspect(opts: &ArgMatches) -> Result<()> {
     let block_paths = opts.values_of("INPUT").unwrap();
     let verbose = opts.is_present("verbose");
-    let stdout = io::stdout();
-    let mut out = io::BufWriter::new(stdout.lock());
+    let stdout = stdout();
+    let mut out = BufWriter::new(stdout.lock());
     for block_path in block_paths {
         out.write_fmt(format_args!("{}\n", block_path))?;
         let block =
@@ -75,7 +75,7 @@ fn inspect(opts: &ArgMatches) -> Result<()> {
 
         if verbose {
             out.write_fmt(format_args!(
-                "{id:>10} {size:>10} {offset:>10} {location_hash:>32} {content_hash:>32} {location:}\n",
+                "{id:>9} {size:>9} {offset:>9} {location_hash:>32} {content_hash:>32} {location:}\n",
                 id = "ID",
                 size = "SIZE",
                 offset = "OFFSET",
@@ -85,7 +85,7 @@ fn inspect(opts: &ArgMatches) -> Result<()> {
             ))?;
         } else {
             out.write_fmt(format_args!(
-                "{id:>10} {size:>10} {offset:>10} {location_hash:>32}\n",
+                "{id:>9} {size:>9} {offset:>9} {location_hash:>32}\n",
                 id = "ID",
                 size = "SIZE",
                 offset = "OFFSET",
@@ -97,21 +97,21 @@ fn inspect(opts: &ArgMatches) -> Result<()> {
             if verbose {
                 let (header, _) = block.file_at(idx)?;
                 out.write_fmt(format_args!(
-                    "{id:>10} {size:>10} {offset:>10} {location_hash:x} {content_hash:x} {location:<}\n",
+                    "{id:>9} {size:>9} {offset:>9} {location_hash:32} {content_hash:32} {location:<}\n",
                     id = file.id,
                     size = file.size,
                     offset = file.offset,
-                    location_hash = file.location_hash,
-                    content_hash = header.hash,
+                    location_hash = format!("{:x}", file.location_hash),
+                    content_hash = format!("{:x}", header.hash),
                     location = header.location,
                 ))?;
             } else {
                 out.write_fmt(format_args!(
-                    "{id:>10} {size:>10} {offset:>10} {location_hash:x}\n",
+                    "{id:>9} {size:>9} {offset:>9} {location_hash:32}\n",
                     id = file.id,
                     size = file.size,
                     offset = file.offset,
-                    location_hash = file.location_hash
+                    location_hash = format!("{:x}", file.location_hash)
                 ))?;
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ extern crate blocky;
 use ::blocky::block::{AddFileRequest, Block};
 use ::blocky::errors::*;
 use clap::{App, ArgMatches, SubCommand};
-use std::io::{self, Write, stdout, BufWriter};
+use std::io::{self, stdout, BufWriter, Write};
 
 quick_main!(application);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,7 +114,9 @@ fn inspect(opts: &ArgMatches) -> Result<()> {
 
         for (idx, file) in block.iter().enumerate() {
             if verbose {
-                let (header, _) = block.file_at(idx).ok_or("Unable to read file from the block")?;
+                let (header, _) = block
+                    .file_at(idx)
+                    .ok_or("Unable to read file from the block")?;
                 out.write_fmt(format_args!(
                     "{id:>9} {size:>9} {offset:>9} {location_hash:32} {content_hash:32} {location:<}\n",
                     id = file.id,
@@ -144,7 +146,9 @@ fn export(opts: &ArgMatches) -> Result<()> {
     let id = value_t!(opts.value_of("ID"), u64)?;
 
     let block = Block::open(block_file)?;
-    let (_, content) = block.file_by_id(id).ok_or(format!("File with id {} not found in a block", id))?;
+    let (_, content) = block
+        .file_by_id(id)
+        .ok_or(format!("File with id {} not found in a block", id))?;
     let out = stdout();
     let mut out = BufWriter::new(out.lock());
     out.write_all(&content)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ fn inspect(opts: &ArgMatches) -> Result<()> {
         out.write_fmt(format_args!("{}\n", block_path))?;
         let block =
             Block::open(block_path).chain_err(|| format!("Fail to open block: {}", block_path))?;
-        
+
         if verbose {
             out.write_fmt(format_args!(
                 "{id:>10} {size:>10} {offset:>10} {location_hash:>32} {content_hash:>32} {location:}\n",
@@ -92,7 +92,6 @@ fn inspect(opts: &ArgMatches) -> Result<()> {
                 location_hash = "LOCATION HASH"
             ))?;
         }
-        
 
         for (idx, file) in block.iter().enumerate() {
             if verbose {
@@ -115,7 +114,6 @@ fn inspect(opts: &ArgMatches) -> Result<()> {
                     location_hash = file.location_hash
                 ))?;
             }
-            
         }
     }
 


### PR DESCRIPTION
Now block contains full content of a file including file location name (eg. URL) and content hash.

- [x] `Block::file_at()` added. Reading file using offset;
- [x] `Block::file_by_id()` added. Reading file using global ID. `O(n)` at the moment.


## inspect command

`inspect` command has `-v` flag. It returns not only URL hash and file id, but also location and content hash:

```
$ cargo run -- inspect test.blk
test.blk
       ID      SIZE    OFFSET                    LOCATION HASH
        1     17418      1024 24f7710da48fe4d200a10fe804e9e85d
        2       611     19456 f094b8ead13abfb86bb1b09ea94a1ea4
        3      5098     20480 8f7b912ee4c888651fca257425bd236e

$ cargo run -- inspect -v test.blk
test.blk
       ID      SIZE    OFFSET                    LOCATION HASH                     CONTENT HASH LOCATION
        1     17418      1024 24f7710da48fe4d200a10fe804e9e85d 331a2ddb9abdb1dbab5eda244c8df32a ../src/block.rs
        2       611     19456 f094b8ead13abfb86bb1b09ea94a1ea4 14df6d23537ff82e858c928bee8bc6c6 ../src/lib.rs
        3      5098     20480 8f7b912ee4c888651fca257425bd236e 25aeb9f9cf50c13c519b402d394cf66d ../src/main.rs
```
## export command

`export` command allows to read a file from block and write it on stdout.

```
$ cargo run -- inspect -v test.blk
test.blk
       ID      SIZE    OFFSET                    LOCATION HASH                     CONTENT HASH LOCATION
        1     17418      1024 24f7710da48fe4d200a10fe804e9e85d 331a2ddb9abdb1dbab5eda244c8df32a ../src/block.rs
$ cargo run -- export test.blk 1 | md5sum
331a2ddb9abdb1dbab5eda244c8df32a
```

## `Makefile` for test block creation

Some utilities for creating test block are added. See `playground/` for more information. General use is:

```
$ cd playground/
$ make clean test.blk
```